### PR TITLE
BuildingCard.tsx Damage Calc Update

### DIFF
--- a/src/components/BuildingCard.tsx
+++ b/src/components/BuildingCard.tsx
@@ -51,6 +51,10 @@ function getZapQuakes(props: Props, buildingLevel: number): ZapQuake[] {
       }
       nbSpells = q + z; // update nbSpells
     }
+    // Can't be destroyed with Zaps alone, reset nbSpells to 0 to continue loop
+    if (result.length === 0){
+      nbSpells = 0
+    }
     hpLeft = hp; // repair building for next test
   }
 


### PR DESCRIPTION
Initial damage loop would cutoff if building couldn't be destroyed with Zaps alone. This change allows the loop to continue if that isn't the case. Tested with Zap 7 and Earthquake 4 against Eagle Artillery 3.